### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
         path: ./target
 
     - name: Build image and Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ghcr.io/kondoumh/sb-sample-service/sb-sample-service
         username: kondoumh


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore